### PR TITLE
Fixes dependency conflict between dai nodes and this repo.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local 
-depthai==3.0.0a15.dev0+dea15ac37846facb677cd784e65d3ca46f08f6c5
+depthai==3.0.0rc2
 git+https://github.com/luxonis/depthai-nodes.git@main#egg=depthai-nodes


### PR DESCRIPTION
## Purpose

Fixes:

```sh
[2025-07-02T12:15:59Z] ERROR: Cannot install -r /app/requirements.txt (line 3) and depthai==3.0.0a15.dev0+dea15ac37846facb677cd784e65d3ca46f08f6c5 because these package versions have conflicting dependencies.
```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable